### PR TITLE
Single target cast fix

### DIFF
--- a/wizwalker/extensions/wizsprinter/sprinty_combat.py
+++ b/wizwalker/extensions/wizsprinter/sprinty_combat.py
@@ -332,6 +332,16 @@ async def does_card_contain_reqs(card: CombatCard, template: TemplateSpell) -> b
                     pass
 
 
+    if matched_reqs == needed_matches and is_aoe_req:
+        # Reject cards that have single-target damage effects — they require
+        # target selection and are not true AOEs (e.g. Storm Beetle: single-target
+        # damage + team blade falsely matches type_aoe via the blade's target).
+        for e in effects:
+            eff_type = await e.effect_type()
+            target = await e.effect_target()
+            if eff_type in damage_effects and target in enemy_targets and target not in aoe_targets:
+                return False
+
     return matched_reqs == needed_matches
 
 

--- a/wizwalker/extensions/wizsprinter/sprinty_combat.py
+++ b/wizwalker/extensions/wizsprinter/sprinty_combat.py
@@ -345,6 +345,17 @@ async def does_card_contain_reqs(card: CombatCard, template: TemplateSpell) -> b
     return matched_reqs == needed_matches
 
 
+async def card_requires_target_selection(card: CombatCard) -> bool:
+    """Check if a card requires the player to select a target (i.e. not a true AOE).
+    Returns True if any damage/steal effect targets a single enemy rather than a team."""
+    effects = await get_inner_card_effects(card)
+    for e in effects:
+        eff_type = await e.effect_type()
+        eff_target = await e.effect_target()
+        if eff_type in damage_effects and eff_target in enemy_targets and eff_target not in aoe_targets:
+            return True
+    return False
+
 
 class SprintyCombat(CombatHandler):
     def __init__(self, client: wizwalker.client.Client, config_provider: BaseCombatBackend, handle_mouseless: bool = False):
@@ -763,6 +774,10 @@ class SprintyCombat(CombatHandler):
         target = await self.try_get_config_target(move_config.target)
 
         if target == False:  # Wouldn't want a None to mess it up
+            return False
+
+        # AOE target (None) but card requires single-target selection — skip
+        if target is None and await card_requires_target_selection(cur_card):
             return False
 
         if cur_card == "willcast":

--- a/wizwalker/extensions/wizsprinter/sprinty_combat.py
+++ b/wizwalker/extensions/wizsprinter/sprinty_combat.py
@@ -776,9 +776,11 @@ class SprintyCombat(CombatHandler):
         if target == False:  # Wouldn't want a None to mess it up
             return False
 
-        # AOE target (None) but card requires single-target selection — skip
-        if target is None and await card_requires_target_selection(cur_card):
-            return False
+        # Card has single-target damage — only compatible with enemy/boss targeting
+        if await card_requires_target_selection(cur_card):
+            ttype = move_config.target.target_type if move_config.target else None
+            if ttype in (TargetType.type_aoe, TargetType.type_self, TargetType.type_ally):
+                return False
 
         if cur_card == "willcast":
             if willcasted:


### PR DESCRIPTION
single hit item cards were being improperly classified as AOEs, that is now fixed. Notably, this was happening with item card Storm Beetle.